### PR TITLE
Feature gate all dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/448-engineering/DirMeta.git"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-file-format = { version = "0.23.0", features = [
+file-format = { version = "0.26.0", optional = true, features = [
     "reader",
     "reader-asf",
     "reader-cfb",
@@ -25,17 +25,34 @@ file-format = { version = "0.23.0", features = [
     "reader-txt",
     "reader-xml",
     "reader-zip",
-
 ] }
-async-recursion = "1.0.5"
-byte_prefix = "1.0.0"
-tai64 = "4.0.0"
-chrono = { version = "0.4.31", optional = true }
-humantime = { version = "2.1.0", optional = true }
-smol = "2.0.0"
-inotify = { version = "0.10.2", default-features = false, optional = true }
+async-recursion = { version = "1.1.1", optional = true }
+byte_prefix = { version = "1.0.0", optional = true }
+tai64 = { version = "4.1.0", optional = true }
+chrono = { version = "0.4.40", optional = true }
+humantime = { version = "2.2.0", optional = true }
+inotify = { version = "0.11.0", default-features = false, optional = true }
+async-fs = { version = "2.1.2", default-features = false, optional = true }
+futures-lite = { version = "2.6.0", default-features = false, optional = true }
+async-io = { version = "2.4.0", default-features = false, optional = true }
+blocking = { version = "1.6.1", optional = true }
+async-channel = { version = "2.3.1", optional = true }
 
 [features]
-default = ["time", "watcher"]
-time = ["dep:chrono", "dep:humantime"]
-watcher = ["dep:inotify"]
+default = ["time", "size", "extra", "file-type"]
+time = ["dep:chrono", "dep:humantime", "dep:tai64"]
+watcher = ["dep:inotify", "dep:async-channel", "dep:futures-lite"]
+async = [
+    "dep:async-recursion",
+    "dep:async-io",
+    "dep:futures-lite",
+    "dep:blocking",
+    "dep:async-fs",
+]
+sync = []
+size = ["dep:byte_prefix", "extra"]
+file-type = ["dep:file-format"]
+extra = []
+
+[dev-dependencies]
+smol = "2.0.2"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ dir-meta = {version = "*", default-features = false} #deactivate methods for con
 ```rust
 smol::block_on(async {
             // Read a directory
-            let outcome = dir_meta::DirMetadata::new("src").dir_metadata().await.unwrap();
+            // With feature `async` enabled using `cargo add dir-meta --features async`
+            let outcome = dir_meta::DirMetadata::new("src").async_dir_metadata().await.unwrap();
 
             dbg!(&outcome);
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,16 +1,20 @@
-use crate::{CowStr, FsUtils};
-use async_recursion::async_recursion;
-use file_format::FileFormat;
-use smol::{
-    fs::{read_dir, ReadDir},
-    io::{self, ErrorKind},
-    stream::StreamExt,
-    unblock,
-};
+use crate::CowStr;
+
 use std::{
     borrow::Cow,
     path::{Path, PathBuf},
 };
+
+#[cfg(feature = "async")]
+use async_recursion::async_recursion;
+
+#[cfg(feature = "async")]
+use futures_lite::StreamExt;
+
+#[cfg(feature = "file-type")]
+use file_format::FileFormat;
+
+#[cfg(feature = "time")]
 use tai64::Tai64N;
 
 #[cfg(feature = "time")]
@@ -21,7 +25,8 @@ use crate::DateTimeString;
 /// ```rust
 /// use dir_meta::DirMetadata;
 ///
-/// let dir = DirMetadata::new("/path/to/directory").dir_metadata();
+/// // With feature `async` enabled using `cargo add dir-meta --features async`
+/// let dir = DirMetadata::new("/path/to/directory").async_dir_metadata();
 /// ```
 #[derive(Debug, PartialEq, Eq, Default, Clone)]
 pub struct DirMetadata<'a> {
@@ -29,41 +34,79 @@ pub struct DirMetadata<'a> {
     path: PathBuf,
     directories: Vec<PathBuf>,
     files: Vec<FileMetadata<'a>>,
+    #[cfg(feature = "extra")]
     size: usize,
     errors: Vec<DirError<'a>>,
 }
 
-impl<'a> DirMetadata<'a> {
+impl<'a> DirMetadata<'_> {
     /// Create a new instance of [Self]
+    /// but with the path as a `&str`
     pub fn new(path: &'a str) -> Self {
-        let dir_name: PathBuf = path.into();
-        let dir_name = dir_name.file_name();
+        Self::new_path_buf(path.into())
+    }
 
-        let name = match dir_name {
-            Some(name) => CowStr::Owned(name.to_string_lossy().to_string()),
-            None => path.into(),
-        };
+    /// Create a new instance of [Self]
+    pub fn new_path_buf(path: PathBuf) -> Self {
+        let name = Cow::Owned(path.file_name().unwrap().to_string_lossy().to_string());
 
-        DirMetadata {
-            path: path.into(),
+        Self {
+            path,
             name,
             ..Default::default()
         }
     }
 
+    /// Multiple files can have the same name if they are in different dirs
+    /// so using this method returns a [vector](Vec) of [FileMetadata]
+    pub fn get_file(&self, file_name: &'a str) -> Vec<&'a FileMetadata> {
+        self.files()
+            .iter()
+            .filter(|file| file.name() == file_name)
+            .collect()
+    }
+
+    /// Get a file by it's absolute path (from root)
+    pub fn get_file_by_path(&self, path: &'a str) -> Option<&'a FileMetadata> {
+        self.files()
+            .iter()
+            .find(|file| file.path() == Path::new(path))
+    }
+
     /// Returns an error if the directory cannot be accessed
-    /// Read all the directories and files in the given path
-    pub async fn dir_metadata(mut self) -> Result<DirMetadata<'a>, io::Error> {
+    /// Read all the directories and files in the given path in async fashion
+    #[cfg(feature = "async")]
+    pub async fn async_dir_metadata(mut self) -> Result<Self, std::io::Error> {
+        use async_fs::read_dir;
+
         let mut dir = read_dir(&self.path).await?;
 
-        self.iter_dir(&mut dir).await;
+        self.async_iter_dir(&mut dir).await;
+
+        Ok(self)
+    }
+
+    /// Returns an error if the directory cannot be accessed
+    /// Read all the directories and files in the given path
+    #[cfg(feature = "sync")]
+    pub fn sync_dir_metadata(mut self) -> Result<Self, std::io::Error> {
+        use std::fs::read_dir;
+        let mut dir = read_dir(&self.path)?;
+
+        self.sync_iter_dir(&mut dir);
 
         Ok(self)
     }
 
     /// Recursively iterate over directories inside directories
+    #[cfg(feature = "async")]
     #[async_recursion]
-    pub async fn iter_dir(&mut self, prepared_dir: &mut ReadDir) -> &mut Self {
+    pub async fn async_iter_dir(
+        &'a mut self,
+        prepared_dir: &mut async_fs::ReadDir,
+    ) -> &'a mut Self {
+        use async_fs::read_dir;
+
         let mut directories = Vec::<PathBuf>::new();
 
         while let Some(entry_result) = prepared_dir.next().await {
@@ -99,25 +142,38 @@ impl<'a> DirMetadata<'a> {
                     } else {
                         let mut file_meta = FileMetadata::default();
 
-                        let cloned_path = entry.path().clone();
-                        let get_file_format = unblock(move || FileFormat::from_file(cloned_path));
-                        let format = match get_file_format.await {
-                            Ok(format_detected) => format_detected,
-                            Err(_) => FileFormat::default(),
-                        };
-                        file_meta.file_format = format;
+                        #[cfg(all(feature = "file-type", feature = "async"))]
+                        {
+                            let cloned_path = entry.path().clone();
+                            let get_file_format =
+                                blocking::unblock(move || FileFormat::from_file(cloned_path));
+                            let format = (get_file_format.await).unwrap_or_default();
+                            file_meta.file_format = format;
+                        }
 
                         file_meta.name =
                             CowStr::Owned(entry.file_name().to_string_lossy().to_string());
                         file_meta.path = entry.path();
+
+                        #[cfg(any(feature = "size", feature = "time", feature = "extra"))]
                         match entry.metadata().await {
                             Ok(meta) => {
-                                let current_file_size = meta.len() as usize;
-                                self.size += current_file_size;
-                                file_meta.size = current_file_size;
-                                file_meta.accessed = FsUtils::maybe_time(meta.accessed().ok());
-                                file_meta.modified = FsUtils::maybe_time(meta.modified().ok());
-                                file_meta.created = FsUtils::maybe_time(meta.created().ok());
+                                #[cfg(feature = "extra")]
+                                {
+                                    let current_file_size = meta.len() as usize;
+                                    self.size += current_file_size;
+                                    file_meta.size = current_file_size;
+                                }
+
+                                #[cfg(feature = "time")]
+                                {
+                                    file_meta.accessed =
+                                        crate::FsUtils::maybe_time(meta.accessed().ok());
+                                    file_meta.modified =
+                                        crate::FsUtils::maybe_time(meta.modified().ok());
+                                    file_meta.created =
+                                        crate::FsUtils::maybe_time(meta.created().ok());
+                                }
                             }
                             Err(error) => {
                                 self.errors.push(DirError {
@@ -137,12 +193,12 @@ impl<'a> DirMetadata<'a> {
             }
         }
 
-        let mut dir_iter = smol::stream::iter(&directories);
+        let mut dir_iter = futures_lite::stream::iter(&directories);
 
         while let Some(path) = dir_iter.next().await {
             match read_dir(path.clone()).await {
                 Ok(mut prepared_dir) => {
-                    self.iter_dir(&mut prepared_dir).await;
+                    self.async_iter_dir(&mut prepared_dir).await;
                 }
                 Err(error) => self.errors.push(DirError {
                     path: path.to_owned(),
@@ -154,6 +210,114 @@ impl<'a> DirMetadata<'a> {
                 }),
             }
         }
+
+        self.directories.extend_from_slice(&directories);
+
+        self
+    }
+
+    /// Recursively iterate over directories inside directories
+    #[cfg(feature = "sync")]
+    pub fn sync_iter_dir(&mut self, prepared_dir: &mut std::fs::ReadDir) -> &mut Self {
+        let mut directories = Vec::<PathBuf>::new();
+
+        prepared_dir
+            .by_ref()
+            .for_each(|entry_result| match entry_result {
+                Err(error) => {
+                    self.errors.push(DirError {
+                        path: self.path.clone(),
+                        error: error.kind(),
+                        display: error.to_string().into(),
+                    });
+                }
+                Ok(entry) => {
+                    let mut is_dir = false;
+
+                    match entry.file_type() {
+                        Ok(file_type) => is_dir = file_type.is_dir(),
+                        Err(error) => {
+                            let inner_path = entry.path();
+
+                            self.errors.push(DirError {
+                                path: inner_path.clone(),
+                                error: error.kind(),
+                                display: Cow::Owned(format!(
+                                    "Unable to check if `{}` is a directory",
+                                    inner_path.display()
+                                )),
+                            });
+                        }
+                    }
+
+                    if is_dir {
+                        directories.push(entry.path())
+                    } else {
+                        let mut file_meta = FileMetadata::default();
+
+                        #[cfg(all(feature = "file-type", feature = "sync"))]
+                        {
+                            let cloned_path = entry.path().clone();
+                            let get_file_format = FileFormat::from_file(cloned_path);
+                            let format = (get_file_format).unwrap_or_default();
+                            file_meta.file_format = format;
+                        }
+
+                        file_meta.name =
+                            CowStr::Owned(entry.file_name().to_string_lossy().to_string());
+                        file_meta.path = entry.path();
+                        #[cfg(any(feature = "size", feature = "time", feature = "extra"))]
+                        match entry.metadata() {
+                            Ok(meta) => {
+                                #[cfg(feature = "extra")]
+                                {
+                                    let current_file_size = meta.len() as usize;
+                                    self.size += current_file_size;
+                                    file_meta.size = current_file_size;
+                                }
+
+                                #[cfg(feature = "time")]
+                                {
+                                    file_meta.accessed =
+                                        crate::FsUtils::maybe_time(meta.accessed().ok());
+                                    file_meta.modified =
+                                        crate::FsUtils::maybe_time(meta.modified().ok());
+                                    file_meta.created =
+                                        crate::FsUtils::maybe_time(meta.created().ok());
+                                }
+                            }
+                            Err(error) => {
+                                self.errors.push(DirError {
+                                    path: entry.path(),
+                                    error: error.kind(),
+                                    display: Cow::Owned(format!(
+                                        "Unable to access metadata of file `{}`",
+                                        entry.path().display()
+                                    )),
+                                });
+                            }
+                        }
+
+                        self.files.push(file_meta);
+                    }
+                }
+            });
+
+        directories
+            .iter()
+            .for_each(|path| match std::fs::read_dir(path.clone()) {
+                Ok(mut prepared_dir) => {
+                    self.sync_iter_dir(&mut prepared_dir);
+                }
+                Err(error) => self.errors.push(DirError {
+                    path: path.to_owned(),
+                    error: error.kind(),
+                    display: Cow::Owned(format!(
+                        "Unable to access metadata of file `{}`",
+                        path.display()
+                    )),
+                }),
+            });
 
         self.directories.extend_from_slice(&directories);
 
@@ -176,22 +340,24 @@ impl<'a> DirMetadata<'a> {
     }
 
     /// Get all the files in the current directory and all the files in it's sub-directory
-    pub fn files(&self) -> &[FileMetadata<'a>] {
+    pub fn files(&'a self) -> &'a [FileMetadata<'a>] {
         self.files.as_ref()
     }
 
     /// Get the size of the directory including the  size of all files in the sub-directories
+    #[cfg(feature = "extra")]
     pub fn size(&self) -> usize {
         self.size
     }
 
     /// Get the size of the directory including the  size of all files in the sub-directories in human readable format
+    #[cfg(feature = "size")]
     pub fn size_formatted(&self) -> String {
-        FsUtils::size_to_bytes(self.size)
+        crate::FsUtils::size_to_bytes(self.size)
     }
 
     /// Get all the errors encountered while opening the sub-directories and files
-    pub fn errors(&self) -> &[DirError<'a>] {
+    pub fn errors(&'a self) -> &'a [DirError<'a>] {
         self.errors.as_ref()
     }
 }
@@ -201,12 +367,19 @@ impl<'a> DirMetadata<'a> {
 pub struct FileMetadata<'a> {
     name: CowStr<'a>,
     path: PathBuf,
+    #[cfg(feature = "extra")]
     size: usize,
+    #[cfg(feature = "extra")]
     read_only: bool,
+    #[cfg(feature = "time")]
     created: Option<Tai64N>,
+    #[cfg(feature = "time")]
     accessed: Option<Tai64N>,
+    #[cfg(feature = "time")]
     modified: Option<Tai64N>,
+    #[cfg(feature = "extra")]
     symlink: bool,
+    #[cfg(feature = "file-type")]
     file_format: FileFormat,
 }
 
@@ -222,26 +395,31 @@ impl<'a> FileMetadata<'a> {
     }
 
     /// Get the size of the file
+    #[cfg(feature = "extra")]
     pub fn size(&self) -> usize {
         self.size
     }
 
     /// Get the size of the file in human readable format
+    #[cfg(feature = "size")]
     pub fn formatted_size(&self) -> String {
-        FsUtils::size_to_bytes(self.size)
+        crate::FsUtils::size_to_bytes(self.size)
     }
 
     /// Get the TAI64N timestamp when the file was last accessed
+    #[cfg(feature = "time")]
     pub fn accessed(&self) -> Option<Tai64N> {
         self.accessed
     }
 
     /// Get the TAI64N timestamp when the file was last modified
+    #[cfg(feature = "time")]
     pub fn modified(&self) -> Option<Tai64N> {
         self.modified
     }
 
     /// Get the TAI64N timestamp when the file was last created
+    #[cfg(feature = "time")]
     pub fn created(&self) -> Option<Tai64N> {
         self.created
     }
@@ -249,68 +427,71 @@ impl<'a> FileMetadata<'a> {
     /// Get the timestamp in local time in 24 hour format when the file was last accessed
     #[cfg(feature = "time")]
     pub fn accessed_24hr(&self) -> Option<DateTimeString<'a>> {
-        Some(FsUtils::tai64_to_local_hrs(&self.accessed?))
+        Some(crate::FsUtils::tai64_to_local_hrs(&self.accessed?))
     }
 
     /// Get the timestamp in local time in 12 hour format when the file was last accessed
     #[cfg(feature = "time")]
     pub fn accessed_am_pm(&self) -> Option<DateTimeString<'a>> {
-        Some(FsUtils::tai64_to_local_am_pm(&self.accessed?))
+        Some(crate::FsUtils::tai64_to_local_am_pm(&self.accessed?))
     }
 
     /// Get the time passed since access of a file eg `3 sec ago`
     #[cfg(feature = "time")]
     pub fn accessed_humatime(&self) -> Option<String> {
-        FsUtils::tai64_now_duration_to_humantime(&self.accessed?)
+        crate::FsUtils::tai64_now_duration_to_humantime(&self.accessed?)
     }
 
     /// Get the timestamp in local time in 24 hour format when the file was last modified
     #[cfg(feature = "time")]
     pub fn modified_24hr(&self) -> Option<DateTimeString<'a>> {
-        Some(FsUtils::tai64_to_local_hrs(&self.modified?))
+        Some(crate::FsUtils::tai64_to_local_hrs(&self.modified?))
     }
 
     /// Get the timestamp in local time in 12 hour format when the file was last modified
     #[cfg(feature = "time")]
     pub fn modified_am_pm(&self) -> Option<DateTimeString<'a>> {
-        Some(FsUtils::tai64_to_local_am_pm(&self.modified?))
+        Some(crate::FsUtils::tai64_to_local_am_pm(&self.modified?))
     }
 
     /// Get the time passed since modification of a file eg `3 sec ago`
     #[cfg(feature = "time")]
     pub fn modified_humatime(&self) -> Option<String> {
-        FsUtils::tai64_now_duration_to_humantime(&self.modified?)
+        crate::FsUtils::tai64_now_duration_to_humantime(&self.modified?)
     }
 
     /// Get the timestamp in local time in 24 hour format when the file was created
     #[cfg(feature = "time")]
     pub fn created_24hr(&self) -> Option<DateTimeString<'a>> {
-        Some(FsUtils::tai64_to_local_hrs(&self.created?))
+        Some(crate::FsUtils::tai64_to_local_hrs(&self.created?))
     }
 
     /// Get the timestamp in local time in 12 hour format when the file was created
     #[cfg(feature = "time")]
     pub fn created_am_pm(&self) -> Option<DateTimeString<'a>> {
-        Some(FsUtils::tai64_to_local_am_pm(&self.created?))
+        Some(crate::FsUtils::tai64_to_local_am_pm(&self.created?))
     }
 
     /// Get the time passed since file was created of a file eg `3 sec ago`
     #[cfg(feature = "time")]
     pub fn created_humatime(&self) -> Option<String> {
-        FsUtils::tai64_now_duration_to_humantime(&self.created?)
+        crate::FsUtils::tai64_now_duration_to_humantime(&self.created?)
     }
 
     /// Is the file read only
+    #[cfg(feature = "extra")]
     pub fn read_only(&self) -> bool {
         self.read_only
     }
 
     /// Is the file a symbolic link
+    #[cfg(feature = "extra")]
     pub fn symlink(&self) -> bool {
         self.symlink
     }
 
     /// Get the format of the current file
+    #[cfg(feature = "file-type")]
     pub fn file_format(&self) -> &FileFormat {
         &self.file_format
     }
@@ -322,7 +503,79 @@ pub struct DirError<'a> {
     /// The path to the sub-directory or file where the error occurred
     pub path: PathBuf,
     /// The kind of error that occurred based on [std::io::ErrorKind]
-    pub error: ErrorKind,
+    pub error: std::io::ErrorKind,
     /// The formatted error as a [String]
     pub display: CowStr<'a>,
+}
+
+#[cfg(test)]
+mod sanity_checks {
+
+    #[cfg(all(feature = "async", feature = "size", feature = "extra"))]
+    #[test]
+    fn async_features() {
+        smol::block_on(async {
+            let outcome = crate::DirMetadata::new("src")
+                .async_dir_metadata()
+                .await
+                .unwrap();
+
+            {
+                #[cfg(feature = "time")]
+                for file in outcome.files() {
+                    assert_ne!("", file.name());
+                    assert_ne!(Option::None, file.accessed_24hr());
+                    assert_ne!(Option::None, file.accessed_am_pm());
+                    assert_ne!(Option::None, file.accessed_humatime());
+                    assert_ne!(Option::None, file.created_24hr());
+                    assert_ne!(Option::None, file.created_am_pm());
+                    assert_ne!(Option::None, file.created_humatime());
+                    assert_ne!(Option::None, file.modified_24hr());
+                    assert_ne!(Option::None, file.modified_am_pm());
+                    assert_ne!(Option::None, file.modified_humatime());
+                    assert_ne!(String::default(), file.formatted_size());
+                }
+            }
+        })
+    }
+
+    #[cfg(all(feature = "sync", feature = "size", feature = "extra"))]
+    #[test]
+    fn sync_features() {
+        use file_format::FileFormat;
+
+        smol::block_on(async {
+            let outcome = crate::DirMetadata::new("src").sync_dir_metadata().unwrap();
+
+            {
+                #[cfg(feature = "time")]
+                for file in outcome.files() {
+                    assert_ne!("", file.name());
+                    assert_ne!(Option::None, file.accessed_24hr());
+                    assert_ne!(Option::None, file.accessed_am_pm());
+                    assert_ne!(Option::None, file.accessed_humatime());
+                    assert_ne!(Option::None, file.created_24hr());
+                    assert_ne!(Option::None, file.created_am_pm());
+                    assert_ne!(Option::None, file.created_humatime());
+                    assert_ne!(Option::None, file.modified_24hr());
+                    assert_ne!(Option::None, file.modified_am_pm());
+                    assert_ne!(Option::None, file.modified_humatime());
+                    assert_ne!(String::default(), file.formatted_size());
+                }
+            }
+
+            #[cfg(feature = "extra")]
+            {
+                assert!(outcome.size() > 0usize);
+            }
+
+            #[cfg(feature = "file-type")]
+            {
+                let path = String::from(env!("CARGO_MANIFEST_DIR")) + "/src";
+                let file = outcome.get_file_by_path(&path);
+                assert!(file.is_some());
+                assert_eq!(file.unwrap().file_format(), &FileFormat::PlainText);
+            }
+        })
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,50 +8,47 @@ pub use utils::*;
 mod fs;
 pub use fs::*;
 
-#[cfg(feature = "time")]
+#[cfg(all(feature = "sync", feature = "async"))]
+compile_error!("Features 'sync' and 'async' cannot be enabled at the same time.");
+
+#[cfg(all(feature = "sync", feature = "watcher"))]
+compile_error!("`watcher` feature can only be compiled with `async` feature.");
+
+#[cfg(feature = "watcher")]
 mod watcher;
 /// This directory inherits most types from `inotify` crate
-#[cfg(feature = "time")]
+#[cfg(feature = "watcher")]
 pub use watcher::*;
 
+#[cfg(feature = "async")]
 pub use async_recursion;
+
+#[cfg(feature = "size")]
 pub use byte_prefix;
+
 #[cfg(feature = "time")]
 pub use chrono;
+
+#[cfg(feature = "file-type")]
 pub use file_format;
+
 #[cfg(feature = "time")]
 pub use humantime;
+
 #[cfg(feature = "watcher")]
 pub use inotify;
-pub use smol;
+
+#[cfg(feature = "watcher")]
+pub use async_channel;
+
+#[cfg(feature = "async")]
+pub use async_io;
+
+#[cfg(feature = "async")]
+pub use futures_lite;
+
+#[cfg(feature = "async")]
+pub use blocking;
+
+#[cfg(feature = "time")]
 pub use tai64;
-
-#[cfg(test)]
-mod sanity_checks {
-    #[test]
-    fn ineq() {
-        smol::block_on(async {
-            let outcome = crate::DirMetadata::new("src").dir_metadata().await.unwrap();
-
-            dbg!(&outcome);
-            dbg!(outcome.size_formatted());
-
-            {
-                #[cfg(feature = "time")]
-                for file in outcome.files() {
-                    assert_ne!("", file.name());
-                    assert_ne!(Option::None, file.accessed_24hr());
-                    assert_ne!(Option::None, file.accessed_am_pm());
-                    assert_ne!(Option::None, file.accessed_humatime());
-                    assert_ne!(Option::None, file.created_24hr());
-                    assert_ne!(Option::None, file.created_am_pm());
-                    assert_ne!(Option::None, file.created_humatime());
-                    assert_ne!(Option::None, file.modified_24hr());
-                    assert_ne!(Option::None, file.modified_am_pm());
-                    assert_ne!(Option::None, file.modified_humatime());
-                    assert_ne!(String::default(), file.formatted_size());
-                }
-            }
-        })
-    }
-}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,22 +2,28 @@
 use chrono::{DateTime, Utc};
 #[cfg(feature = "time")]
 use std::time::Duration;
-use std::{borrow::Cow, time::SystemTime};
+
+#[cfg(feature = "time")]
+use std::time::SystemTime;
+
+#[cfg(feature = "time")]
 use tai64::Tai64N;
 
 /// Reusable Clone-on-Write str with lifetime of `'a`
-pub type CowStr<'a> = Cow<'a, str>;
+pub type CowStr<'a> = std::borrow::Cow<'a, str>;
 
 /// A convenience struct to access utilities
 pub struct FsUtils;
 
 impl FsUtils {
     /// Returns [Option::None] if time query is not supported
+    #[cfg(feature = "time")]
     pub fn maybe_time(time_result: Option<SystemTime>) -> Option<Tai64N> {
         time_result.map(|time| Tai64N::from_system_time(&time))
     }
 
     /// Calculate the size in bytes
+    #[cfg(feature = "size")]
     pub fn size_to_bytes(bytes: usize) -> String {
         byte_prefix::calc_bytes(bytes as f32)
     }


### PR DESCRIPTION
Require all dependencies to be feature gated to pick and choose what to use. This is useful in situations where all the directory and file metadata is not required or when choosing between async and sync methods of walking through the directories.

- `async` feature to walk the directory asynchronously
- `sync` feature to walk the directory synchronously
- `watcher` feature to enable watching of the directories
- `extra` feature to enable reading file sizes and checking if a file is a symlink
- `time` feature to enable reading the timestamps of the files and converting of those timestamps to human readable timestamp or to Tai64N
- `size` feature enables reading the file sizes in human readable format `MiB`